### PR TITLE
Add get_message_by_id MCP endpoint

### DIFF
--- a/conversations/mcp/server.py
+++ b/conversations/mcp/server.py
@@ -44,6 +44,17 @@ def create_mcp_server():
                 }
             ),
             types.Tool(
+                name="get_message_by_id",
+                description="Get a specific message by its UUID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "message_id": {"type": "string", "description": "The UUID of the message to retrieve"}
+                    },
+                    "required": ["message_id"]
+                }
+            ),
+            types.Tool(
                 name="get_messages_before",
                 description="Get N messages before a given message or timestamp",
                 inputSchema={

--- a/conversations/mcp/tools.py
+++ b/conversations/mcp/tools.py
@@ -33,6 +33,31 @@ async def handle_get_latest_continuation():
     return [types.TextContent(type="text", text=str(continuation.content))]
 
 
+async def handle_get_message_by_id(arguments):
+    """Get a specific message by UUID"""
+    message_id = arguments.get("message_id")
+
+    if not message_id:
+        return [types.TextContent(type="text", text="Error: message_id is required")]
+
+    message = await sync_to_async(MemoryService.get_message_by_id)(message_id)
+
+    if not message:
+        return [types.TextContent(type="text", text=f"Message '{message_id}' not found")]
+
+    lines = [
+        f"Message ID: {message.id}",
+        f"Sender: {message.sender_id}",
+        f"Created: {message.created_at.isoformat()}",
+        f"Timestamp: {message.timestamp}",
+        f"Context Heap: {message.context_heap_id}",
+        f"Message Number: {message.message_number}",
+        f"\nContent:\n{str(message.content)}"
+    ]
+
+    return [types.TextContent(type="text", text='\n'.join(lines))]
+
+
 async def handle_get_messages_before(arguments):
     """Get messages before a reference point"""
     reference_id = arguments.get("reference_id") if arguments else None
@@ -156,6 +181,7 @@ async def handle_random_messages(arguments):
 TOOL_HANDLERS = {
     "bootstrap_memory": handle_bootstrap_memory,
     "get_latest_continuation": handle_get_latest_continuation,
+    "get_message_by_id": handle_get_message_by_id,
     "get_messages_before": handle_get_messages_before,
     "get_era_summary": handle_get_era_summary,
     "get_context_heap": handle_get_context_heap,

--- a/conversations/services/memory.py
+++ b/conversations/services/memory.py
@@ -21,6 +21,14 @@ class MemoryService:
         ).order_by('-created_at').first()
 
     @staticmethod
+    def get_message_by_id(message_id):
+        """Get a specific message by its UUID"""
+        try:
+            return Message.objects.get(id=message_id)
+        except Message.DoesNotExist:
+            return None
+
+    @staticmethod
     def get_messages_before(reference_id=None, reference_timestamp=None, limit=300):
         """Get N messages before a reference point"""
         if reference_id:


### PR DESCRIPTION
## Summary
- Adds new MCP endpoint to retrieve a specific message by its UUID
- Useful for cross-referencing messages between different sessions
- Helpful when looking up messages shown in the stream view

## Changes
- `conversations/services/memory.py`: Added `get_message_by_id` method
- `conversations/mcp/tools.py`: Added handler function and registered in TOOL_HANDLERS
- `conversations/mcp/server.py`: Added tool definition for MCP discovery

## Usage
```
mcp__magenta-memory-v2__get_message_by_id(message_id="<uuid>")
```