### PR TITLE
magenta.sh: stop passing --dangerously-skip-permissions to `claude attach`

### DIFF
--- a/magenta.sh
+++ b/magenta.sh
@@ -292,7 +292,13 @@ except Exception:
             SESS_ID=\$(lookup_claude_session_id \"\$SESSION_NAME\")
             if [ -n \"\$SESS_ID\" ]; then
                 echo \"→ Found Claude session '\$SESSION_NAME' (id \$SESS_ID). Attaching.\"
-                INNER=\"cd ~ && claude attach \$CLAUDE_FLAGS \$SESS_ID\"
+                # No \$CLAUDE_FLAGS here: 'claude attach' takes only <id> and
+                # hard-errors on unknown options ('unknown option
+                # --dangerously-skip-permissions', exit 1), which kills the tmux
+                # session instantly and drops your mosh connection. Harmless to
+                # omit anyway — permission mode is fixed at process start, and
+                # the session was already created with the flag below.
+                INNER=\"cd ~ && claude attach \$SESS_ID\"
             else
                 echo \"→ No Claude session named '\$SESSION_NAME' — creating one\"
                 echo \"─── claude --bg output ───────────────────────────────────\"
@@ -306,7 +312,8 @@ except Exception:
                 SESS_ID=\$(lookup_claude_session_id \"\$SESSION_NAME\")
                 if [ -n \"\$SESS_ID\" ]; then
                     echo \"→ Created and attaching (id \$SESS_ID)\"
-                    INNER=\"cd ~ && claude attach \$CLAUDE_FLAGS \$SESS_ID\"
+                    # See note above: 'claude attach' rejects extra flags.
+                    INNER=\"cd ~ && claude attach \$SESS_ID\"
                 else
                     echo \"\"
                     echo \"⚠️  Session '\$SESSION_NAME' was not registered after --bg attempt.\"


### PR DESCRIPTION
## The bug

`claude attach` takes only `<id>` and hard-errors on any option — verified on hunter, claude 2.1.220:

```
$ claude attach --dangerously-skip-permissions zzzznope
warning: extra arguments ignored: zzzznope
unknown option '--dangerously-skip-permissions'
Usage: claude attach <id>
(exit 1)
```

In `--session` mode that command *is* the tmux session's `INNER`, on both attach paths (line 295: session already exists; line 309: freshly created via `--bg`). So it exited immediately → tmux exited → mosh's remote command finished → mosh quit. That's the "it errored out so fast I wasn't able to see" symptom exactly.

## The fix

Drop `$CLAUDE_FLAGS` from the two `claude attach` invocations. Costs nothing: bypass mode is fixed at process start, so `attach` could never have applied it regardless.

## Other `$CLAUDE_FLAGS` sites — all verified fine

| line | command | accepts flag? |
|---|---|---|
| 286 | `claude agents $CLAUDE_FLAGS` | yes (in `--help`, exit 0) |
| 289 | `claude $CLAUDE_FLAGS 'reawaken magent'` | yes |
| 308 | `claude $CLAUDE_FLAGS --bg --name ...` | yes (Justin ran it, exit 0) |
| 333/336 | `claude $CLAUDE_FLAGS --continue` | yes (parses, exit 0) |

`bash -n magenta.sh` passes.

https://claude.ai/code/session_01LdqD9r9TBuTMutksVS8r7T